### PR TITLE
Update install.sub

### DIFF
--- a/connect/install.sub
+++ b/connect/install.sub
@@ -69,7 +69,7 @@ install_paramiko () {
 				--log="${builddir}/log" \
 				-b "${builddir}" \
 				--target="$target" \
-				pycrypto paramiko \
+				paramiko \
 		) > pip.log 2>&1 ||
 		{ code=$?; echo "== Do you need to load a python module?"; }
 		rm -rf "${builddir}"


### PR DESCRIPTION
Hello,
While trying to install the connect client on python 2.7.11, I realized pycrypto is tried to be installed along with paramiko. However, PyCrypto itself isn't used and current versions of `paramiko` rely on `cryptography` instead, which is already in paramiko's requirements ( so no need to add it in install.sub)

Pycrypto actually crashes in some python versions of CMS, but paramiko + cryptography works fine, so removing this old dependency fixes the client installation for that case.